### PR TITLE
ヘッダーにアカウントボタンを追加

### DIFF
--- a/src/global/header.vue
+++ b/src/global/header.vue
@@ -6,7 +6,8 @@ import { useStore } from "vuex";
 
 const router = useRouter();
 const store = useStore();
-const isAuth = !!store.getters["auth/getUid"];
+const { uid, name: userName, email: userEmail } = store.getters["auth/getUser"];
+const isAuth = !!uid;
 
 const logout = async () => {
   try {
@@ -28,9 +29,31 @@ const logout = async () => {
       <v-spacer></v-spacer>
       <v-sheet color="primary" v-if="isAuth">
         <v-btn class="bg-secondary" to="/"> 感想一覧 </v-btn>
-        <v-btn class="bg-error ml-4 mr-2" @click="logout"
-          >ログアウト<v-icon class="ml-2">mdi-logout</v-icon>
-        </v-btn>
+
+        <v-menu transition="scale-transition">
+          <template v-slot:activator="{ props }">
+            <v-btn class="bg-white ml-4 mr-2" color="primary" v-bind="props">
+              アカウント
+            </v-btn>
+          </template>
+
+          <v-list>
+            <v-list-item>
+              <v-list-item-title>
+                <p>{{ userName || "名前未設定" }}さん</p>
+                <p class="d-flex justify-center text-subtitle-2">
+                  {{ userEmail }}
+                </p>
+              </v-list-item-title>
+            </v-list-item>
+            <v-divider></v-divider>
+            <v-list-item>
+              <v-list-item-title @click="logout" class="logout-item"
+                >ログアウト<v-icon class="ml-2">mdi-logout</v-icon>
+              </v-list-item-title>
+            </v-list-item>
+          </v-list>
+        </v-menu>
       </v-sheet>
       <v-sheet color="primary" v-else="isAuth">
         <v-btn class="bg-white mr-2" color="indigo" to="/login"
@@ -41,4 +64,8 @@ const logout = async () => {
   </div>
 </template>
 
-<style lang="css" scoped></style>
+<style lang="css" scoped>
+.logout-item:hover {
+  cursor: pointer;
+}
+</style>

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -25,8 +25,9 @@ const signIn = () => {
       // 成功時処理
       const user = userCredential.user;
       store.dispatch("auth/SetUserStateAction", {
-        name: user.email,
+        name: user.displayName,
         uid: user.uid,
+        email: user.email,
       });
       await router.push("/");
       location.reload();

--- a/src/store/auth/index.ts
+++ b/src/store/auth/index.ts
@@ -3,6 +3,7 @@ import type { Commit } from "vuex";
 type User = {
   name: string;
   uid: string;
+  email: string;
 };
 
 interface State {
@@ -15,7 +16,7 @@ const initUser = (): User => {
     const parsedUser = JSON.parse(user);
     return parsedUser;
   } else {
-    return { name: "", uid: "" };
+    return { name: "", uid: "", email: "" };
   }
 };
 
@@ -37,6 +38,9 @@ const actions = {
 };
 
 const getters = {
+  getUser(state: State): User {
+    return state.user;
+  },
   getUid(state: State): string {
     return state.user.uid;
   },


### PR DESCRIPTION
- ヘッダーのログアウトボタンを削除し、アカウントボタンを追加
- アカウントボタンを押下するとメニューが展開され、以下が表示される
  - ログイン中のアカウント情報（アカウント名（*）とemaiアドレス）
*アカウント名はサインアップ時に登録する想定だが、まだ未実装
  - ログアウトメニュー 
